### PR TITLE
Added runs_once_per_instance decorator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     description = """ Expose class members as Fabric tasks """,
 
     long_description = open('README.rst').read(),
-    requires = ['Fabric (>= 1.1)'],
+    requires = [
+        'Fabric (>= 1.1)',
+        'decorator (>= 3.3.3)',  # older versions untested; probably OK though
+    ],
 
     classifiers=(
         'Development Status :: 3 - Alpha',

--- a/taskset/__init__.py
+++ b/taskset/__init__.py
@@ -9,8 +9,8 @@ from decorator import decorator
 def runs_once_per_instance(func, *args, **kwargs):
     '''
     Decorator to prevent wrapped method from running more than once per
-    taskset instance (run_once prevents the method from running more
-    than once per overall python interpreter invocation, which probably
+    taskset instance (fabric's @runs_once prevents the method from running
+    more than once per overall python interpreter invocation, which probably
     isn't what you want if you have multiple instances of the taskset).
     '''
     obj = args[0]


### PR DESCRIPTION
I added a runs_once_per_instance decorator, because with runs_once, the decorated method only runs once per python invocation -- including on descendants.  Example:

``` python
# base.py
from taskset import TaskSet, task
from fabric.api import runs_once

class Base(TaskSet):
    @runs_once
    @task
    def once(self):
        print('only runs once, ever')

    @runs_once_per_instance
    @task
    def per_instance(self):
        print('runs once per instance')

# foo.py
from base import Base

class Foo(Base):
    pass

instance = Foo()
instance.expose_to_current_module()

# bar.py
from base import Base

class Bar(Base):
    pass

instance = Bar()
instance.expose_to_current_module()

# fabfile.py
import foo
import bar
```

``` bash
$ fab foo.once bar.once
only runs once, ever

Done.
$ fab foo.per_instance bar.per_instance
runs once per instance
runs once per instance

Done.
```
